### PR TITLE
Revert "Bump rack from 2.2.6.4 to 2.2.8.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    rack (2.2.8.1)
+    rack (2.2.6.4)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)


### PR DESCRIPTION
Reverts Winbobob/winbobob.github.io#15